### PR TITLE
add --cuda_id parameter

### DIFF
--- a/SinGAN/functions.py
+++ b/SinGAN/functions.py
@@ -281,6 +281,7 @@ def generate_dir2save(opt):
 
 def post_config(opt):
     # init fixed parameters
+    os.environ["CUDA_VISIBLE_DEVICES"] = str(opt.cuda_id)
     opt.device = torch.device("cpu" if opt.not_cuda else "cuda:0")
     opt.niter_init = opt.niter
     opt.noise_amp_init = opt.noise_amp

--- a/config.py
+++ b/config.py
@@ -6,6 +6,7 @@ def get_arguments():
     #parser.add_argument('--mode', help='task to be done', default='train')
     #workspace:
     parser.add_argument('--not_cuda', action='store_true', help='disables cuda', default=0)
+    parser.add_argument('--cuda_id', help='the cuda id of the GPU to train on',default='0')
     
     #load, input, save configurations:
     parser.add_argument('--netG', default='', help="path to netG (to continue training)")


### PR DESCRIPTION
for servers with more than a single GPU it is possible to choose on which one to run, using a cuda_id and settings an environment variable to include it.