### PR TITLE
Fix wrong pairing between files in SIFID

### DIFF
--- a/SIFID/sifid_score.py
+++ b/SIFID/sifid_score.py
@@ -212,7 +212,7 @@ def _compute_statistics_of_path(files, model, batch_size, dims, cuda):
         f.close()
     else:
         path = pathlib.Path(path)
-        files = list(path.glob('*.jpg'))+ list(path.glob('*.png'))
+        files = sorted(list(path.glob('*.jpg'))+ list(path.glob('*.png')))
         m, s = calculate_activation_statistics(files, model, batch_size,
                                                dims, cuda)
 
@@ -229,10 +229,10 @@ def calculate_sifid_given_paths(path1, path2, batch_size, cuda, dims, suffix):
         model.cuda()
 
     path1 = pathlib.Path(path1)
-    files1 = list(path1.glob('*.%s' %suffix))
+    files1 = sorted(list(path1.glob('*.%s' %suffix)))
 
     path2 = pathlib.Path(path2)
-    files2 = list(path2.glob('*.%s' %suffix))
+    files2 = sorted(list(path2.glob('*.%s' %suffix)))
 
     fid_values = []
     Im_ind = []


### PR DESCRIPTION
We encountered a bug when different images were compared to each other. The root cause is that `glob(...)` doesn't always keep order, so `files1` and `files2` were ordered differently.
A fix for that bug was sorting `files1` and `files2`. We assume that in each list, all the paths are in the same directory, and that files have the same name between the two lists - so sorting the two lists would guarantee a matching order.