### PR TITLE
Fixed issue for recent pytorch versions caused by missing "detach"

### DIFF
--- a/SinGAN/training.py
+++ b/SinGAN/training.py
@@ -172,7 +172,7 @@ def train_single_scale(netD,netG,reals,Gs,Zs,in_s,NoiseAmp,opt,centers=None):
 
         for j in range(opt.Gsteps):
             netG.zero_grad()
-            output = netD(fake)
+            output = netD(fake.detach())
             #D_fake_map = output.detach()
             errG = -output.mean()
             errG.backward(retain_graph=True)


### PR DESCRIPTION
Inplace modification was signaled during start of training:

"RuntimeError:` one of the variables needed for gradient computation has been modified by an inplace operation"