### PR TITLE
Fix an error in calculating SIFID

### DIFF
--- a/SIFID/inception.py
+++ b/SIFID/inception.py
@@ -70,7 +70,7 @@ class InceptionV3(nn.Module):
         self.blocks.append(nn.Sequential(*block0))
 
         # Block 1: maxpool1 to maxpool2
-        if self.last_needed_block >= 1:
+        if self.last_needed_block >= 0:
             block1 = [
                 nn.MaxPool2d(kernel_size=3, stride=2),
                 inception.Conv2d_3b_1x1,
@@ -79,7 +79,7 @@ class InceptionV3(nn.Module):
             self.blocks.append(nn.Sequential(*block1))
 
         # Block 2: maxpool2 to aux classifier
-        if self.last_needed_block >= 2:
+        if self.last_needed_block >= 1:
             block2 = [
                 nn.MaxPool2d(kernel_size=3, stride=2),
                 inception.Mixed_5b,
@@ -94,7 +94,7 @@ class InceptionV3(nn.Module):
             self.blocks.append(nn.Sequential(*block2))
 
         # Block 3: aux classifier to final avgpool
-        if self.last_needed_block >= 3:
+        if self.last_needed_block >= 2:
             block3 = [
                 inception.Mixed_7a,
                 inception.Mixed_7b,
@@ -102,7 +102,7 @@ class InceptionV3(nn.Module):
             ]
             self.blocks.append(nn.Sequential(*block3))
 
-        if self.last_needed_block >= 4:
+        if self.last_needed_block >= 3:
             block4 = [
                 nn.AdaptiveAvgPool2d(output_size=(1, 1))
             ]

--- a/SIFID/inception.py
+++ b/SIFID/inception.py
@@ -70,7 +70,7 @@ class InceptionV3(nn.Module):
         self.blocks.append(nn.Sequential(*block0))
 
         # Block 1: maxpool1 to maxpool2
-        if self.last_needed_block >= 0:
+        if self.last_needed_block >= 1:
             block1 = [
                 nn.MaxPool2d(kernel_size=3, stride=2),
                 inception.Conv2d_3b_1x1,
@@ -79,7 +79,7 @@ class InceptionV3(nn.Module):
             self.blocks.append(nn.Sequential(*block1))
 
         # Block 2: maxpool2 to aux classifier
-        if self.last_needed_block >= 1:
+        if self.last_needed_block >= 2:
             block2 = [
                 nn.MaxPool2d(kernel_size=3, stride=2),
                 inception.Mixed_5b,
@@ -94,7 +94,7 @@ class InceptionV3(nn.Module):
             self.blocks.append(nn.Sequential(*block2))
 
         # Block 3: aux classifier to final avgpool
-        if self.last_needed_block >= 2:
+        if self.last_needed_block >= 3:
             block3 = [
                 inception.Mixed_7a,
                 inception.Mixed_7b,
@@ -102,7 +102,7 @@ class InceptionV3(nn.Module):
             ]
             self.blocks.append(nn.Sequential(*block3))
 
-        if self.last_needed_block >= 3:
+        if self.last_needed_block >= 4:
             block4 = [
                 nn.AdaptiveAvgPool2d(output_size=(1, 1))
             ]

--- a/SIFID/sifid_score.py
+++ b/SIFID/sifid_score.py
@@ -51,7 +51,7 @@ parser.add_argument('-c', '--gpu', default='', type=str, help='GPU to use (leave
 parser.add_argument('--images_suffix', default='jpg', type=str, help='image file suffix')
 
 
-def get_activations(files, model, batch_size=1, dims=64,
+def get_activations(files, model, batch_size=1, dims=192,
                     cuda=False, verbose=False):
     """Calculates the activations of the pool_3 layer for all images.
 
@@ -183,7 +183,7 @@ def calculate_frechet_distance(mu1, sigma1, mu2, sigma2, eps=1e-6):
 
 
 def calculate_activation_statistics(files, model, batch_size=1,
-                                    dims=64, cuda=False, verbose=False):
+                                    dims=192, cuda=False, verbose=False):
     """Calculation of the statistics used by the FID.
     Params:
     -- files       : List of image files paths
@@ -255,7 +255,7 @@ if __name__ == '__main__':
     path2 = args.path2fake
     suffix = args.images_suffix
 
-    sifid_values = calculate_sifid_given_paths(path1,path2,1,args.gpu!='',64,suffix)
+    sifid_values = calculate_sifid_given_paths(path1,path2,1,args.gpu!='',192,suffix)
 
     sifid_values = np.asarray(sifid_values,dtype=np.float32)
     numpy.save('SIFID', sifid_values)


### PR DESCRIPTION
I got the same issue with #155.

In the current code, the SIFID is calculated from the activation before the first pooling layer.
To calculate the SIFID as described in the paper, the following modifications are required.

https://github.com/tamarott/SinGAN/blob/286d3cd51cc327381737844d330348ec97577e60/SIFID/inception.py#L53
If 'dims' is set to 64, 'self.last_needed_block' is set to 0.

https://github.com/tamarott/SinGAN/blob/286d3cd51cc327381737844d330348ec97577e60/SIFID/inception.py#L62-L79
Then the input feature map only passed through 'block0'. 
It doesn't go through the first max-pooling layer.